### PR TITLE
specify longer timeout for readiness probe

### DIFF
--- a/deploy/scaleway-webhook/templates/deployment.yaml
+++ b/deploy/scaleway-webhook/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
               path: /healthz
               port: https
           readinessProbe:
+            timeoutSeconds: 5
             httpGet:
               scheme: HTTPS
               path: /healthz


### PR DESCRIPTION
I was on Kapsule 1.20.x, I just upgraded to Kapsule 1.21.x, and now when I redeploy my helm chart, I get this error:
```
helm upgrade --install -f env/preprod.yaml infra helm/infra/
Error: UPGRADE FAILED: cannot patch "wildcard-cert" with kind Certificate: Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": context deadline exceeded
```

Looking at scaleway-webhook pod, there is an issue with the readiness probe:
```
kubectl describe pod/scaleway-webhook-587b778874-m5q74
  Normal   Started    104s  kubelet            Started container scaleway-webhook
  Warning  Unhealthy  102s  kubelet            Readiness probe failed: Get "https://100.64.2.134:443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

Reading https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
It appears that the default timeout is 1s, I had to change the helm chart to use
```
readinessProbe:
  timeoutSeconds: 5
```
(I didn't test lower than 5s)

and redeploy:
```
helm upgrade scaleway-webhook deploy/scaleway-webhook --set secret.accessKey=$SCW_ACCESS_KEY --set secret.secretKey=$SCW_SECRET_KEY
```

to fix the issue.